### PR TITLE
feat: allow specifying base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ new AppStoreConnectAPI({
 });
 ```
 
+### Overriding the base URL
+
+For integration testing purposes, you can override the base path of the App Store Connect API by setting the `basePath` option in the AppStoreConnectAPI constructor. For example, you can use this to point to a local mock server. This allows you to test the behavior of your application in a more controlled environment without making requests to the real API.
+
+```typescript
+import AppStoreConnectAPI from "appstore-connect-sdk";
+
+new AppStoreConnectAPI({
+  // ...
+  basePath: "http://localhost:3000", // All network requests are made to http://localhost:3000
+});
+```
+
 ## Updating OpenAPI generated code
 
 To update the OpenAPI-generated code, run the following command:

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,11 @@ interface AppStoreConnectAPIOptions {
    * The time (in seconds) until the token expires (default 10 minutes)
    */
   expirationTime?: number;
+
+  /**
+   * The base path for the API (without trailing slash, default https://api.appstoreconnect.apple.com).
+   */
+  basePath?: string;
 }
 
 /**
@@ -57,6 +62,7 @@ export default class AppStoreConnectAPI {
    * @param options.fetchApi - (Optional) The FetchAPI implementation to use for API requests.
    * @param options.bearerToken - (Optional) A pre-generated bearer token to use for authentication.
    * @param options.expirationTime - (Optional) The time (in seconds) until the token expires (default 10 minutes)
+   * @param options.basePath - (Optional) The base path for the API (without trailing slash, default https://api.appstoreconnect.apple.com).
    * @throws {string} Will throw an error if no bearerToken or private key is provided
    */
   constructor(options: AppStoreConnectAPIOptions) {
@@ -91,6 +97,7 @@ export default class AppStoreConnectAPI {
         Authorization: `Bearer ${await this.genToken()}`,
       },
       fetchApi: this.options.fetchApi,
+      basePath: this.options.basePath?.replace(/\/$/, ""),
     });
     this.bearerTokenGeneratedAt = Date.now();
   }

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -11,22 +11,58 @@ jest.setTimeout(30000);
 // Load the environment variables from the .env file.
 dotenv.config();
 
-// Create a new instance of the AppStoreConnectAPI client with the required parameters.
-const client = new AppStoreConnectAPI({
-  issuerId: process.env.ISSUER_ID!,
-  privateKeyId: process.env.PRIVATE_KEY_ID!,
-  privateKey: process.env.PRIVATE_KEY!,
-  fetchApi: fetch as unknown as FetchAPI,
-});
+describe("AppStoreConnectAPI", () => {
+  let client: AppStoreConnectAPI;
 
-// Test case to get a list of apps.
-test("Get app list", async () => {
-  try {
-    const api = await client.create(AppsApi);
-    const res = await api.appsGetCollection();
-    console.log(res);
-    expect(res).toBeDefined;
-  } catch (error) {
-    console.error(error);
-  }
+  beforeAll(() => {
+    client = new AppStoreConnectAPI({
+      issuerId: process.env.ISSUER_ID!,
+      privateKeyId: process.env.PRIVATE_KEY_ID!,
+      privateKey: process.env.PRIVATE_KEY!,
+      fetchApi: fetch as unknown as FetchAPI,
+    });
+  });
+
+  test("should interact with the App Store Connect API", async () => {
+    try {
+      const api = await client.create(AppsApi);
+      const res = await api.appsGetCollection();
+      console.log(res);
+      expect(res).toBeDefined;
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
+  describe("with base path override", () => {
+    let client: AppStoreConnectAPI;
+
+    beforeAll(() => {
+      client = new AppStoreConnectAPI({
+        issuerId: process.env.ISSUER_ID!,
+        privateKeyId: process.env.PRIVATE_KEY_ID!,
+        privateKey: process.env.PRIVATE_KEY!,
+        fetchApi: fetch as unknown as FetchAPI,
+        basePath: "https://jsonplaceholder.typicode.com",
+      });
+    });
+
+    test("should use the overridden base path", async () => {
+      const configuration = await client.getConfiguration();
+      expect(configuration?.basePath).toBe(
+        "https://jsonplaceholder.typicode.com"
+      );
+    });
+
+    test("should correctly concatenate overridden base path with endpoint", async () => {
+      try {
+        const api = await client.create(AppsApi);
+        await api.appsGetCollection();
+      } catch (error: any) {
+        expect(error.response.url).toBe(
+          "https://jsonplaceholder.typicode.com/v1/apps"
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a new option to the client configuration object called `basePath` which can be used to override the default path (`https://api.appstoreconnect.apple.com`) of the requests. This can be useful for testing purposes, since we can make the library point to an in-house mock server that uses dummy data/fixtures instead of making requests to the real API.

`basePath` is already a supported option in the runtime file generated by OpenAPI, the client just didn't allow the possibility to pass a different URL to it.

I also added unit tests to make sure this new behavior works as intended, as well as a new sub-section in the readme. I did not make changes to the Chinese readme.